### PR TITLE
fix: copy artifacts as enriched text (html + plain)

### DIFF
--- a/src/renderer/components/MessageItemArtifactBlock.vue
+++ b/src/renderer/components/MessageItemArtifactBlock.vue
@@ -42,7 +42,10 @@ import ContextMenuTrigger from './ContextMenuTrigger.vue'
 import MessageItemBody from './MessageItemBody.vue'
 
 const content = () => extractCodeBlockContent(props.content)
-const { copying, onCopy } = useArtifactCopy(content)
+const { copying, onCopy } = useArtifactCopy({
+  plainText: content,
+  html: () => window.api.markdown.render(content()),
+})
 
 const downloadButton = ref<HTMLElement>(null)
 const panelBody = ref<HTMLElement>(null)
@@ -143,6 +146,8 @@ const onDownloadFormat = async (action: string) => {
     }
   })
 }
+
+defineExpose({ onCopy })
 
 </script>
 

--- a/src/renderer/components/MessageItemHtmlBlock.vue
+++ b/src/renderer/components/MessageItemHtmlBlock.vue
@@ -49,7 +49,10 @@ import MessageItemBody from './MessageItemBody.vue'
 const content = () => extractCodeBlockContent(props.content)
 
 const { onDomEvent } = useEventListener()
-const { copying, onCopy } = useArtifactCopy(content)
+const { copying, onCopy } = useArtifactCopy({
+  plainText: () => extractPlainText(extractHtmlContent()),
+  html: () => extractHtmlContent(),
+})
 
 const previewHtml = ref(false)
 const htmlRenderingDelayPassed = ref(false)
@@ -85,6 +88,11 @@ const extractBodyContent = (htmlContent: string) => {
   const bodyEnd = htmlContent.lastIndexOf('</body>')
   if (bodyEnd === -1) return htmlContent.slice(bodyTagEnd + 1)
   return htmlContent.slice(bodyTagEnd + 1, bodyEnd)
+}
+
+const extractPlainText = (htmlContent: string) => {
+  const doc = new DOMParser().parseFromString(htmlContent, 'text/html')
+  return doc.body?.innerText?.trim() || doc.body?.textContent?.trim() || ''
 }
 
 const isDarkMode = () => {
@@ -279,6 +287,8 @@ onBeforeUnmount(() => {
 const toggleHtml = () => {
   previewHtml.value = !previewHtml.value
 }
+
+defineExpose({ onCopy })
 
 const onDownloadFormat = async (action: string) => {
 

--- a/src/renderer/composables/artifact_copy.ts
+++ b/src/renderer/composables/artifact_copy.ts
@@ -1,14 +1,46 @@
 import { ref } from 'vue'
 
-export function useArtifactCopy(contentGetter: () => string) {
+export interface ArtifactCopySource {
+  plainText: () => string
+  html?: () => string
+}
+
+export function useArtifactCopy(source: ArtifactCopySource | (() => string)) {
   const copying = ref(false)
 
-  const onCopy = () => {
+  const resolve = (): ArtifactCopySource => {
+    return typeof source === 'function' ? { plainText: source } : source
+  }
+
+  const onCopy = async () => {
     copying.value = true
-    navigator.clipboard.writeText(contentGetter())
-    setTimeout(() => {
-      copying.value = false
-    }, 1000)
+
+    const { plainText, html } = resolve()
+    const plainContent = plainText()
+    const htmlContent = html?.()
+
+    try {
+      if (htmlContent && window.ClipboardItem && navigator.clipboard?.write) {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            'text/html': new Blob([htmlContent], { type: 'text/html' }),
+            'text/plain': new Blob([plainContent], { type: 'text/plain' }),
+          }),
+        ])
+      } else {
+        await navigator.clipboard.writeText(plainContent)
+      }
+    } catch {
+      try {
+        await navigator.clipboard.writeText(plainContent)
+      } catch {
+        // copying state is reset in finally
+      }
+    } finally {
+      setTimeout(() => {
+        copying.value = false
+      }, 1000)
+    }
   }
 
   return {

--- a/tests/unit/renderer/components/message_item_artifact_block.test.ts
+++ b/tests/unit/renderer/components/message_item_artifact_block.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18nMock } from '@tests/mocks'
+import { useWindowMock } from '@tests/mocks/window'
+import { stubTeleport } from '@tests/mocks/stubs'
+import MessageItemArtifactBlock from '@components/MessageItemArtifactBlock.vue'
+import { store } from '@services/store'
+
+vi.mock('@services/i18n', async () => {
+  return createI18nMock()
+})
+
+class ClipboardItemMock {
+  items: Record<string, Blob>
+  constructor(items: Record<string, Blob>) {
+    this.items = items
+  }
+}
+
+const blobText = (b: Blob & { __text?: string }): string => b.__text ?? ''
+
+const installBlobCapture = () => {
+  const OriginalBlob = window.Blob
+  window.Blob = class CapturingBlob extends OriginalBlob {
+    __text: string
+    constructor(parts: BlobPart[], options?: BlobPropertyBag) {
+      super(parts, options)
+      this.__text = parts.map(p => typeof p === 'string' ? p : '').join('')
+    }
+  } as unknown as typeof Blob
+  return () => { window.Blob = OriginalBlob }
+}
+
+describe('MessageItemArtifactBlock copy', () => {
+
+  beforeAll(() => {
+    useWindowMock()
+    store.loadSettings()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    delete (window as Window & { ClipboardItem?: typeof ClipboardItem }).ClipboardItem
+  })
+
+  const mountArtifactBlock = (content: string) => {
+    return mount(MessageItemArtifactBlock, {
+      ...stubTeleport,
+      props: {
+        title: 'Markdown Artifact',
+        content,
+        transient: false,
+      },
+    })
+  }
+
+  test('copies rendered html + raw markdown when ClipboardItem is available', async () => {
+    const restoreBlob = installBlobCapture()
+    try {
+      const write = vi.fn().mockResolvedValue(undefined)
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.assign(navigator, { clipboard: { write, writeText } })
+      window.ClipboardItem = ClipboardItemMock as unknown as typeof ClipboardItem
+
+      const wrapper = mountArtifactBlock('```\n# Heading\n\n**bold** text\n```')
+
+      await wrapper.vm.onCopy()
+
+      expect(write).toHaveBeenCalledTimes(1)
+      expect(writeText).not.toHaveBeenCalled()
+
+      const items = write.mock.calls[0][0]
+      const htmlBlob = items[0].items['text/html'] as Blob
+      const plainBlob = items[0].items['text/plain'] as Blob
+      expect(htmlBlob.type).toBe('text/html')
+      expect(plainBlob.type).toBe('text/plain')
+
+      const htmlText = blobText(htmlBlob)
+      const plainText = blobText(plainBlob)
+      expect(htmlText).toContain('<h1>')
+      expect(htmlText).toContain('<strong>bold</strong>')
+      expect(plainText).toContain('# Heading')
+      expect(plainText).toContain('**bold**')
+    } finally {
+      restoreBlob()
+    }
+  })
+
+  test('falls back to raw markdown as plain text when rich clipboard is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    const wrapper = mountArtifactBlock('```\n# Heading\n\n**bold** text\n```')
+
+    await wrapper.vm.onCopy()
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    const copied = writeText.mock.calls[0][0]
+    expect(copied).toContain('# Heading')
+    expect(copied).toContain('**bold**')
+  })
+})

--- a/tests/unit/renderer/components/message_item_html_block.test.ts
+++ b/tests/unit/renderer/components/message_item_html_block.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18nMock } from '@tests/mocks'
+import { useWindowMock } from '@tests/mocks/window'
+import { stubTeleport } from '@tests/mocks/stubs'
+import MessageItemHtmlBlock from '@components/MessageItemHtmlBlock.vue'
+import { store } from '@services/store'
+
+vi.mock('@services/i18n', async () => {
+  return createI18nMock()
+})
+
+class ClipboardItemMock {
+  items: Record<string, Blob>
+  constructor(items: Record<string, Blob>) {
+    this.items = items
+  }
+}
+
+describe('MessageItemHtmlBlock copy', () => {
+
+  beforeAll(() => {
+    useWindowMock()
+    store.loadSettings()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    delete (window as Window & { ClipboardItem?: typeof ClipboardItem }).ClipboardItem
+  })
+
+  const mountHtmlArtifactBlock = (content: string) => {
+    return mount(MessageItemHtmlBlock, {
+      ...stubTeleport,
+      props: {
+        title: 'HTML Artifact',
+        content,
+        transient: false,
+      },
+    })
+  }
+
+  test('copies rich html when ClipboardItem support exists', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { write, writeText } })
+    window.ClipboardItem = ClipboardItemMock as unknown as typeof ClipboardItem
+
+    const wrapper = mountHtmlArtifactBlock('```html\n<!DOCTYPE html><html><body><h1>Hello</h1><p>World</p></body></html>\n```')
+
+    await wrapper.vm.onCopy()
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(writeText).not.toHaveBeenCalled()
+
+    const clipboardItems = write.mock.calls[0][0]
+    expect(clipboardItems).toHaveLength(1)
+    expect(clipboardItems[0]).toBeInstanceOf(ClipboardItemMock)
+    expect(clipboardItems[0].items['text/html']).toBeInstanceOf(Blob)
+    expect(clipboardItems[0].items['text/plain']).toBeInstanceOf(Blob)
+    expect(clipboardItems[0].items['text/html'].type).toBe('text/html')
+    expect(clipboardItems[0].items['text/plain'].type).toBe('text/plain')
+    expect(clipboardItems[0].items['text/html'].size).toBeGreaterThan(0)
+    expect(clipboardItems[0].items['text/plain'].size).toBeGreaterThan(0)
+  })
+
+  test('falls back to plain text without raw html when rich clipboard is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+
+    const wrapper = mountHtmlArtifactBlock('```html\n<!DOCTYPE html><html><body><h1>Hello</h1><p>World</p></body></html>\n```')
+
+    await wrapper.vm.onCopy()
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+
+    const copiedText = writeText.mock.calls[0][0]
+    expect(copiedText).toContain('Hello')
+    expect(copiedText).toContain('World')
+    expect(copiedText).not.toContain('<html')
+    expect(copiedText).not.toContain('<body')
+  })
+})

--- a/tests/unit/renderer/composables/artifact_copy.test.ts
+++ b/tests/unit/renderer/composables/artifact_copy.test.ts
@@ -1,18 +1,26 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { useArtifactCopy } from '@composables/artifact_copy'
 
-// Mock clipboard API
-Object.assign(navigator, {
-  clipboard: {
-    writeText: vi.fn().mockResolvedValue(undefined),
-  },
-})
+class ClipboardItemMock {
+  items: Record<string, Blob>
+  constructor(items: Record<string, Blob>) {
+    this.items = items
+  }
+}
+
+const setClipboard = (impl: Partial<Clipboard>) => {
+  Object.assign(navigator, { clipboard: impl })
+}
 
 describe('useArtifactCopy', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.useFakeTimers()
+    delete (window as Window & { ClipboardItem?: typeof ClipboardItem }).ClipboardItem
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   test('copying flag is initially false', () => {
@@ -20,49 +28,99 @@ describe('useArtifactCopy', () => {
     expect(copying.value).toBe(false)
   })
 
-  test('onCopy sets copying flag to true', () => {
-    const { copying, onCopy } = useArtifactCopy(() => 'test content')
-    onCopy()
-    expect(copying.value).toBe(true)
-  })
+  test('legacy signature writes plain text only', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
 
-  test('onCopy calls clipboard.writeText with content', () => {
     const contentGetter = vi.fn(() => 'my test content')
-    const { onCopy } = useArtifactCopy(contentGetter)
+    const { copying, onCopy } = useArtifactCopy(contentGetter)
 
-    onCopy()
+    const promise = onCopy()
+    expect(copying.value).toBe(true)
+    await promise
+
     expect(contentGetter).toHaveBeenCalled()
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('my test content')
+    expect(writeText).toHaveBeenCalledWith('my test content')
   })
 
-  test('onCopy resets copying flag after 1 second', () => {
-    const { copying, onCopy } = useArtifactCopy(() => 'test content')
+  test('plainText-only source writes plain text only', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const write = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText, write })
 
-    onCopy()
+    const { onCopy } = useArtifactCopy({ plainText: () => 'plain only' })
+    await onCopy()
+
+    expect(writeText).toHaveBeenCalledWith('plain only')
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  test('writes rich html + plain text when ClipboardItem is available', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ write, writeText })
+    window.ClipboardItem = ClipboardItemMock as unknown as typeof ClipboardItem
+
+    const { onCopy } = useArtifactCopy({
+      plainText: () => 'hello world',
+      html: () => '<p>hello <b>world</b></p>',
+    })
+    await onCopy()
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(writeText).not.toHaveBeenCalled()
+
+    const items = write.mock.calls[0][0]
+    expect(items).toHaveLength(1)
+    expect(items[0]).toBeInstanceOf(ClipboardItemMock)
+    expect(items[0].items['text/html']).toBeInstanceOf(Blob)
+    expect(items[0].items['text/plain']).toBeInstanceOf(Blob)
+    expect(items[0].items['text/html'].type).toBe('text/html')
+    expect(items[0].items['text/plain'].type).toBe('text/plain')
+  })
+
+  test('falls back to plain text when ClipboardItem is missing even if html given', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+
+    const { onCopy } = useArtifactCopy({
+      plainText: () => 'plain fallback',
+      html: () => '<p>should not be used</p>',
+    })
+    await onCopy()
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(writeText).toHaveBeenCalledWith('plain fallback')
+  })
+
+  test('falls back to writeText when rich write() throws', async () => {
+    const write = vi.fn().mockRejectedValue(new Error('sandboxed'))
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ write, writeText })
+    window.ClipboardItem = ClipboardItemMock as unknown as typeof ClipboardItem
+
+    const { onCopy } = useArtifactCopy({
+      plainText: () => 'recover me',
+      html: () => '<p>recover me</p>',
+    })
+    await onCopy()
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(writeText).toHaveBeenCalledWith('recover me')
+  })
+
+  test('copying flag resets after 1 second', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    setClipboard({ writeText })
+
+    const { copying, onCopy } = useArtifactCopy(() => 'x')
+    const promise = onCopy()
     expect(copying.value).toBe(true)
+    await promise
 
-    // Advance timers by 1 second
     vi.advanceTimersByTime(1000)
-    expect(copying.value).toBe(false)
-  })
-
-  test('onCopy resets copying flag after timeout even if called multiple times', () => {
-    const { copying, onCopy } = useArtifactCopy(() => 'test content')
-
-    onCopy()
-    expect(copying.value).toBe(true)
-
-    // Call again before timeout
-    vi.advanceTimersByTime(500)
-    onCopy()
-    expect(copying.value).toBe(true)
-
-    // First timeout should fire
-    vi.advanceTimersByTime(500)
-    expect(copying.value).toBe(false)
-
-    // Second timeout should fire
-    vi.advanceTimersByTime(500)
     expect(copying.value).toBe(false)
   })
 


### PR DESCRIPTION
HTML and markdown artifacts now write both text/html and text/plain to the clipboard via ClipboardItem, so pasting into Docs/Outlook/Slack keeps formatting while terminals and plain-text fields still get clean source. Falls back to writeText when ClipboardItem isn't available or the rich write throws.

## Description
<!-- Briefly describe what this PR changes and why -->

## Related Issues
<!-- Reference any related issues, tasks, or discussions -->
Fixes #

## Testing
<!-- Describe how this has been tested -->
- [ ] Manual testing
- [ ] Unit tests added/updated
- [ ] E2E tests (if applicable)

## Checklist
- [ ] Read and followed [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Based on latest `main` branch
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] Unit test coverage maintained/improved
- [ ] Updated README.md (if applicable)

## Contributor License Agreement
<!-- The CLA protects both contributors and the project - it's a standard practice for open source projects -->
<!-- Check https://github.com/Kochava-Studios/witsy/wiki/Contributor-License-Agreement -->
- [ ] I have signed the [Contributor License Agreement](../CLA.md)
