### PR TITLE
Fix native shortcut modifier matching

### DIFF
--- a/src/main/keymonitor.ts
+++ b/src/main/keymonitor.ts
@@ -8,6 +8,7 @@ import { loadSettings } from './config'
 
 const isMac = process.platform === 'darwin'
 const isLinux = process.platform === 'linux'
+const MULTI_MODIFIER_ACTIVATION_DELAY_MS = 120
 
 // Platform-specific key codes for modifier keys
 const MODIFIER_KEY_CODES: Record<string, number> = isMac ? {
@@ -130,6 +131,11 @@ type ParsedNativeShortcut = {
   requiredModifiers: number[] // key codes of required modifiers
 }
 
+type PendingShortcut = {
+  shortcut: ParsedNativeShortcut
+  timer: ReturnType<typeof setTimeout>
+}
+
 export default class KeyMonitor {
 
   private app: App
@@ -140,7 +146,8 @@ export default class KeyMonitor {
   // Track state
   private heldModifiers: Set<number> = new Set()
   private modifierPressedAlone: Map<number, boolean> = new Map() // true if no other key pressed while held
-  private activeShortcuts: Set<string> = new Set() // shortcuts currently "down"
+  private activeShortcuts: Set<keyof NativeShortcutCallbacks> = new Set() // shortcuts currently "down"
+  private pendingShortcuts: Map<keyof NativeShortcutCallbacks, PendingShortcut> = new Map()
 
   // Static methods for use without instance
   static isPlatformSupported(): boolean {
@@ -296,6 +303,7 @@ export default class KeyMonitor {
       this.heldModifiers.clear()
       this.modifierPressedAlone.clear()
       this.activeShortcuts.clear()
+      this.clearPendingShortcuts()
       console.info('[keymonitor] Stopped')
     } catch (error) {
       console.error('[keymonitor] Stop failed:', error)
@@ -348,6 +356,15 @@ export default class KeyMonitor {
     this.heldModifiers.add(keyCode)
     this.modifierPressedAlone.set(keyCode, true)
 
+    if (this.heldModifiers.size > 1) {
+      for (const modKeyCode of this.heldModifiers) {
+        this.modifierPressedAlone.set(modKeyCode, false)
+      }
+      this.releaseActiveModifierOnlyShortcutsForModifiers(this.heldModifiers)
+    }
+
+    this.cancelInvalidPendingShortcuts()
+
     // Check single modifier-only shortcuts (onDown)
     this.checkModifierOnlyShortcuts(keyCode, 'down')
 
@@ -358,8 +375,15 @@ export default class KeyMonitor {
   // Common modifier up handling (both platforms)
   private handleModifierUp(keyCode: number): void {
     const wasAlone = this.modifierPressedAlone.get(keyCode) ?? false
+
+    // A clean quick tap of a multi-modifier combo can be released before the
+    // delayed activation fires. Trigger it now so tap mode still works.
+    this.firePendingShortcutsForReleasedModifier(keyCode)
+
     this.heldModifiers.delete(keyCode)
     this.modifierPressedAlone.delete(keyCode)
+
+    this.cancelPendingShortcuts((shortcut) => shortcut.requiredModifiers.includes(keyCode))
 
     // Check single modifier-only shortcuts (onUp only if pressed alone)
     if (wasAlone) {
@@ -375,14 +399,17 @@ export default class KeyMonitor {
 
     const keyCode = event.keyCode
 
+    this.cancelPendingShortcuts()
+
     // Mark all held modifiers as "not alone"
     for (const modKeyCode of this.heldModifiers) {
       this.modifierPressedAlone.set(modKeyCode, false)
     }
+    this.releaseActiveModifierOnlyShortcutsForModifiers(this.heldModifiers)
 
     // Check modifier+key shortcuts
     for (const shortcut of this.nativeShortcuts) {
-      if (shortcut.keyCode === keyCode && this.areModifiersHeld(shortcut.requiredModifiers)) {
+      if (shortcut.keyCode === keyCode && this.areExactModifiersHeld(shortcut.requiredModifiers)) {
         if (!this.activeShortcuts.has(shortcut.name)) {
           this.activeShortcuts.add(shortcut.name)
           console.debug(`[keymonitor] ${shortcut.name} onDown`)
@@ -429,17 +456,17 @@ export default class KeyMonitor {
     // Check for multi-modifier combos (no key, multiple modifiers)
     for (const shortcut of this.nativeShortcuts) {
       // Must be a multi-modifier combo: no modifierKeyCode, no keyCode, multiple requiredModifiers
-      if (shortcut.modifierKeyCode === undefined &&
-          shortcut.keyCode === undefined &&
-          shortcut.requiredModifiers.length > 1) {
-        // Check if all required modifiers are held
-        if (this.areModifiersHeld(shortcut.requiredModifiers)) {
-          if (!this.activeShortcuts.has(shortcut.name)) {
-            this.activeShortcuts.add(shortcut.name)
-            console.debug(`[keymonitor] ${shortcut.name} onDown (multi-modifier combo)`)
-            this.callbacks[shortcut.name].onDown()
-          }
-        }
+      if (!this.isMultiModifierCombo(shortcut)) {
+        continue
+      }
+
+      if (!this.areExactModifiersHeld(shortcut.requiredModifiers)) {
+        this.cancelPendingShortcut(shortcut.name)
+        continue
+      }
+
+      if (!this.activeShortcuts.has(shortcut.name) && !this.pendingShortcuts.has(shortcut.name)) {
+        this.schedulePendingShortcut(shortcut)
       }
     }
   }
@@ -457,5 +484,90 @@ export default class KeyMonitor {
 
   private areModifiersHeld(requiredModifiers: number[]): boolean {
     return requiredModifiers.every(mod => this.heldModifiers.has(mod))
+  }
+
+  private releaseActiveModifierOnlyShortcutsForModifiers(keyCodes: Iterable<number>): void {
+    const keyCodeSet = new Set(keyCodes)
+
+    for (const shortcut of this.nativeShortcuts) {
+      if (shortcut.name &&
+          shortcut.modifierKeyCode !== undefined &&
+          keyCodeSet.has(shortcut.modifierKeyCode) &&
+          this.activeShortcuts.has(shortcut.name)) {
+        this.activeShortcuts.delete(shortcut.name)
+        console.debug(`[keymonitor] ${shortcut.name} onUp (modifier no longer alone)`)
+        this.callbacks[shortcut.name].onUp()
+      }
+    }
+  }
+
+  private areExactModifiersHeld(requiredModifiers: number[]): boolean {
+    return this.heldModifiers.size === requiredModifiers.length && this.areModifiersHeld(requiredModifiers)
+  }
+
+  private isMultiModifierCombo(shortcut: ParsedNativeShortcut): boolean {
+    return shortcut.modifierKeyCode === undefined &&
+      shortcut.keyCode === undefined &&
+      shortcut.requiredModifiers.length > 1
+  }
+
+  private schedulePendingShortcut(shortcut: ParsedNativeShortcut): void {
+    if (!shortcut.name) return
+
+    const timer = setTimeout(() => {
+      this.firePendingShortcut(shortcut.name)
+    }, MULTI_MODIFIER_ACTIVATION_DELAY_MS)
+
+    this.pendingShortcuts.set(shortcut.name, { shortcut, timer })
+  }
+
+  private firePendingShortcut(name: keyof NativeShortcutCallbacks): void {
+    const pending = this.pendingShortcuts.get(name)
+    if (!pending) return
+
+    this.pendingShortcuts.delete(name)
+    clearTimeout(pending.timer)
+
+    if (!this.areExactModifiersHeld(pending.shortcut.requiredModifiers) || this.activeShortcuts.has(name)) {
+      return
+    }
+
+    this.activeShortcuts.add(name)
+    console.debug(`[keymonitor] ${name} onDown (multi-modifier combo)`)
+    this.callbacks[name].onDown()
+  }
+
+  private firePendingShortcutsForReleasedModifier(keyCode: number): void {
+    const pendingNames = Array.from(this.pendingShortcuts.values())
+      .filter(({ shortcut }) => shortcut.name && shortcut.requiredModifiers.includes(keyCode) && this.areExactModifiersHeld(shortcut.requiredModifiers))
+      .map(({ shortcut }) => shortcut.name)
+
+    for (const name of pendingNames) {
+      this.firePendingShortcut(name)
+    }
+  }
+
+  private cancelInvalidPendingShortcuts(): void {
+    this.cancelPendingShortcuts((shortcut) => !this.areExactModifiersHeld(shortcut.requiredModifiers))
+  }
+
+  private cancelPendingShortcuts(predicate?: (shortcut: ParsedNativeShortcut) => boolean): void {
+    for (const [name, pending] of this.pendingShortcuts) {
+      if (!predicate || predicate(pending.shortcut)) {
+        this.cancelPendingShortcut(name)
+      }
+    }
+  }
+
+  private cancelPendingShortcut(name: keyof NativeShortcutCallbacks): void {
+    const pending = this.pendingShortcuts.get(name)
+    if (!pending) return
+
+    clearTimeout(pending.timer)
+    this.pendingShortcuts.delete(name)
+  }
+
+  private clearPendingShortcuts(): void {
+    this.cancelPendingShortcuts()
   }
 }

--- a/tests/unit/main/keymonitor.test.ts
+++ b/tests/unit/main/keymonitor.test.ts
@@ -27,8 +27,9 @@ vi.mock('../../../src/main/monitor', () => ({
   }
 }))
 
-// macOS key codes for assertions (same as in keymonitor.ts for darwin)
-const MODIFIER_KEY_CODES: Record<string, number> = {
+const platform = process.platform
+
+const MODIFIER_KEY_CODES: Record<string, number> = platform === 'darwin' ? {
   rightCommand: 54,
   leftCommand: 55,
   rightShift: 60,
@@ -37,19 +38,175 @@ const MODIFIER_KEY_CODES: Record<string, number> = {
   leftOption: 58,
   rightControl: 62,
   leftControl: 59,
+} : platform === 'linux' ? {
+  rightCommand: 126,
+  leftCommand: 125,
+  rightShift: 54,
+  leftShift: 42,
+  rightOption: 100,
+  leftOption: 56,
+  rightControl: 97,
+  leftControl: 29,
+} : {
+  rightCommand: 0x5C,
+  leftCommand: 0x5B,
+  rightShift: 0xA1,
+  leftShift: 0xA0,
+  rightOption: 0xA5,
+  leftOption: 0xA4,
+  rightControl: 0xA3,
+  leftControl: 0xA2,
 }
 
-const KEY_CODES: Record<string, number> = {
-  // Letters
+const KEY_CODES: Record<string, number> = platform === 'darwin' ? {
   A: 0, B: 11, C: 8, D: 2, E: 14, F: 3, G: 5, H: 4, I: 34, J: 38,
   K: 40, L: 37, M: 46, N: 45, O: 31, P: 35, Q: 12, R: 15, S: 1, T: 17,
   U: 32, V: 9, W: 13, X: 7, Y: 16, Z: 6,
-  // Numbers
   '0': 29, '1': 18, '2': 19, '3': 20, '4': 21,
   '5': 23, '6': 22, '7': 26, '8': 28, '9': 25,
-  // Special keys
   Space: 49,
   Return: 36,
+  Tab: 48,
+} : platform === 'linux' ? {
+  A: 30, B: 48, C: 46, D: 32, E: 18, F: 33, G: 34, H: 35, I: 23, J: 36,
+  K: 37, L: 38, M: 50, N: 49, O: 24, P: 25, Q: 16, R: 19, S: 31, T: 20,
+  U: 22, V: 47, W: 17, X: 45, Y: 21, Z: 44,
+  '0': 11, '1': 2, '2': 3, '3': 4, '4': 5,
+  '5': 6, '6': 7, '7': 8, '8': 9, '9': 10,
+  Space: 57,
+  Return: 28,
+  Tab: 15,
+} : {
+  A: 0x41, B: 0x42, C: 0x43, D: 0x44, E: 0x45, F: 0x46, G: 0x47, H: 0x48, I: 0x49, J: 0x4A,
+  K: 0x4B, L: 0x4C, M: 0x4D, N: 0x4E, O: 0x4F, P: 0x50, Q: 0x51, R: 0x52, S: 0x53, T: 0x54,
+  U: 0x55, V: 0x56, W: 0x57, X: 0x58, Y: 0x59, Z: 0x5A,
+  '0': 0x30, '1': 0x31, '2': 0x32, '3': 0x33, '4': 0x34,
+  '5': 0x35, '6': 0x36, '7': 0x37, '8': 0x38, '9': 0x39,
+  Space: 0x20,
+  Return: 0x0D,
+  Tab: 0x09,
+}
+
+const createEvent = (type: 'down' | 'up' | 'flagsChanged', keyCode: number) => ({
+  type,
+  keyCode,
+  flags: 0,
+  isRepeat: false,
+})
+
+describe('KeyMonitor multi-modifier matching', () => {
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('delays multi-modifier activation and fires while still held', () => {
+    const { monitor, onDown, onUp } = createMonitor()
+
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftOption))
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftCommand))
+
+    vi.advanceTimersByTime(119)
+    expect(onDown).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(onDown).toHaveBeenCalledTimes(1)
+    expect(onUp).not.toHaveBeenCalled()
+
+    monitor.handleKeyEvent(createEvent('up', MODIFIER_KEY_CODES.leftCommand))
+    expect(onUp).toHaveBeenCalledTimes(1)
+  })
+
+  test('fires a clean quick tap on release before the activation delay', () => {
+    const { monitor, onDown, onUp } = createMonitor()
+
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftOption))
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftCommand))
+    monitor.handleKeyEvent(createEvent('up', MODIFIER_KEY_CODES.leftCommand))
+
+    expect(onDown).toHaveBeenCalledTimes(1)
+    expect(onUp).toHaveBeenCalledTimes(1)
+  })
+
+  test('cancels multi-modifier activation when a regular key is pressed', () => {
+    const { monitor, onDown, onUp } = createMonitor()
+
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftOption))
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftCommand))
+    monitor.handleKeyEvent(createEvent('down', KEY_CODES.Tab))
+
+    vi.advanceTimersByTime(120)
+
+    expect(onDown).not.toHaveBeenCalled()
+    expect(onUp).not.toHaveBeenCalled()
+  })
+
+  test('requires an exact modifier set for multi-modifier activation', () => {
+    const { monitor, onDown, onUp } = createMonitor()
+
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftOption))
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftCommand))
+    monitor.handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftShift))
+
+    vi.advanceTimersByTime(120)
+
+    expect(onDown).not.toHaveBeenCalled()
+    expect(onUp).not.toHaveBeenCalled()
+  })
+
+  test('requires an exact modifier set for native modifier plus key shortcuts', () => {
+    const onDown = vi.fn()
+    const monitor = new KeyMonitor({} as any, {
+      dictation: { onDown, onUp: vi.fn() },
+    } as any)
+    const shortcut = KeyMonitor.parseNativeShortcut({ type: 'native', leftOption: true, leftCommand: true, key: 'Space' })!
+    shortcut.name = 'dictation'
+    ;(monitor as any).nativeShortcuts = [shortcut]
+
+    ;(monitor as any).handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftOption))
+    ;(monitor as any).handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftCommand))
+    ;(monitor as any).handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftShift))
+    ;(monitor as any).handleKeyEvent(createEvent('down', KEY_CODES.Space))
+
+    expect(onDown).not.toHaveBeenCalled()
+  })
+
+  test('releases an active modifier-only shortcut when it becomes a chord', () => {
+    const onDown = vi.fn()
+    const onUp = vi.fn()
+    const monitor = new KeyMonitor({} as any, {
+      dictation: { onDown, onUp },
+    } as any)
+    const shortcut = KeyMonitor.parseNativeShortcut({ type: 'native', leftOption: true })!
+    shortcut.name = 'dictation'
+    ;(monitor as any).nativeShortcuts = [shortcut]
+
+    ;(monitor as any).handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftOption))
+    expect(onDown).toHaveBeenCalledTimes(1)
+
+    ;(monitor as any).handleKeyEvent(createEvent('down', MODIFIER_KEY_CODES.leftShift))
+    expect(onUp).toHaveBeenCalledTimes(1)
+
+    ;(monitor as any).handleKeyEvent(createEvent('up', MODIFIER_KEY_CODES.leftOption))
+    expect(onUp).toHaveBeenCalledTimes(1)
+  })
+
+})
+
+const createMonitor = () => {
+  const onDown = vi.fn()
+  const onUp = vi.fn()
+  const monitor = new KeyMonitor({} as any, {
+    dictation: { onDown, onUp },
+  } as any)
+  const shortcut = KeyMonitor.parseNativeShortcut({ type: 'native', leftOption: true, leftCommand: true })!
+  shortcut.name = 'dictation'
+  ;(monitor as any).nativeShortcuts = [shortcut]
+  return { monitor: monitor as any, onDown, onUp, shortcut }
 }
 
 describe('KeyMonitor parseNativeShortcut', () => {


### PR DESCRIPTION
Closes #569.

## Summary
- require exact modifier sets for native modifier+key and modifier-only combo shortcuts
- delay multi-modifier combo activation briefly so `Alt+Tab`/other key chords can cancel it before callbacks fire
- release active modifier-only shortcuts when they become part of a chord
- make keymonitor tests platform-aware and cover the Windows `Alt+Win` regression cases

## Verification
- `npm test -- tests/unit/main/keymonitor.test.ts`
- `npx eslint src/main/keymonitor.ts tests/unit/main/keymonitor.test.ts`
- `npx vue-tsc --noEmit --project tsconfig.lint.json`
- `git diff --check`